### PR TITLE
fix: Allow using ':' or the configured rest_api_separator.

### DIFF
--- a/src/apps/relay/userdb.c
+++ b/src/apps/relay/userdb.c
@@ -327,7 +327,13 @@ static turn_time_t get_rest_api_timestamp(char *usname) {
   turn_time_t ts = 0;
   int ts_set = 0;
 
+  char rest_api_separator = turn_params.rest_api_separator;
   char *col = strchr(usname, turn_params.rest_api_separator);
+  if (!col && rest_api_separator != ':') {
+    // Try using the default ":" instead.
+    rest_api_separator = ':';
+    col = strchr(usname, rest_api_separator);
+  }
 
   if (col) {
     if (col == usname) {
@@ -349,7 +355,7 @@ static turn_time_t get_rest_api_timestamp(char *usname) {
         *col = 0;
         ts = (turn_time_t)atol(usname);
         ts_set = 1;
-        *col = turn_params.rest_api_separator;
+        *col = rest_api_separator;
       }
     }
   }
@@ -363,7 +369,15 @@ static turn_time_t get_rest_api_timestamp(char *usname) {
 
 static char *get_real_username(char *usname) {
   if (usname[0] && turn_params.use_auth_secret_with_timestamp) {
+
+    char rest_api_separator = turn_params.rest_api_separator;
     char *col = strchr(usname, turn_params.rest_api_separator);
+    if (!col && rest_api_separator != ':') {
+      // Try using the default ":" instead.
+      rest_api_separator = ':';
+      col = strchr(usname, rest_api_separator);
+    }
+
     if (col) {
       if (col == usname) {
         usname += 1;
@@ -382,7 +396,7 @@ static char *get_real_username(char *usname) {
         } else {
           *col = 0;
           usname = strdup(usname);
-          *col = turn_params.rest_api_separator;
+          *col = rest_api_separator;
           return usname;
         }
       }


### PR DESCRIPTION
# Related Issues

- https://github.com/SolinkCorp/interlink/issues/141

# Summary

We generate credentials for the TURN server using [this spec](https://datatracker.ietf.org/doc/html/draft-uberti-behave-turn-rest-00).  This asks us to generate a username which is essentially `${unixExpiry}:${username}`.  The problem is that MediaMTX didn't support the `:` in it's configuration, so we used the custom `_` separator instead.  Now we want to switch to `:` because MediaMTX supports it, and more TURN servers support it, but switching it will break all the existing clients until they get new credentials.

So, this PR is a custom version of coturn, based on the 4.6.2 release, that will look for whatever the configured separator is, and if it's missing, will try using the `:` separator.  The idea is we can run this for a few days while we switch over.

I've built this and pushed a docker image to `150303506660.dkr.ecr.us-west-2.amazonaws.com/coturn-custom:v4.6.2-custom`.